### PR TITLE
fix(openapi-generator-cli): use correct format for additionalProperties

### DIFF
--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
@@ -63,7 +63,7 @@ function generateSources(
     const args = ['generate', '-i', apiSpecPathOrUrl, '-g', generator, '-o', outputDir];
 
     if (additionalProperties) {
-      args.push(...['--additional-properties', additionalProperties]);
+      args.push(`--additional-properties=${additionalProperties}`);
     }
 
     if (apiSpecAuthorizationHeaders) {


### PR DESCRIPTION
Per the documentation: https://openapi-generator.tech/docs/usage#additional-properties

> --additional-properties=prependFormOrBodyParameters=true