### PR TITLE
feat(nx-plugin-openapi): allow the user to specify an alternate docker image

### DIFF
--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
@@ -19,6 +19,7 @@ export default async function runExecutor(
 
   await generateSources(
     options.useDockerBuild ?? false,
+    options.dockerImage ?? 'openapitools/openapi-generator-cli:latest',
     options.sourceSpecPathOrUrl,
     options.sourceSpecUrlAuthorizationHeaders,
     options.generator,
@@ -33,6 +34,7 @@ export default async function runExecutor(
 
 async function generateSources(
   useDockerBuild: boolean,
+  dockerImage: string,
   apiSpecPathOrUrl: string,
   apiSpecAuthorizationHeaders: string,
   generator: string,
@@ -47,7 +49,7 @@ async function generateSources(
     const { command, args } = useDockerBuild
       ? {
           command: 'docker',
-          args: ['run', '--rm', '-v', `${process.cwd()}:/local`, '-w', '/local', 'openapitools/openapi-generator-cli'],
+          args: ['run', '--rm', '-v', `${process.cwd()}:/local`, '-w', '/local', dockerImage],
         }
       : { command: 'npx', args: ['openapi-generator-cli'] };
 

--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.d.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.d.ts
@@ -2,6 +2,7 @@ export interface GenerateApiLibSourcesExecutorSchema {
   generator: string;
   sourceSpecPathOrUrl: string;
   useDockerBuild?: boolean;
+  dockerImage?: string;
   sourceSpecUrlAuthorizationHeaders?: string;
   additionalProperties?: string;
   globalProperties?: string;

--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.json
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.json
@@ -10,6 +10,11 @@
       "description": "Should the build occur inside of a docker container",
       "default": false
     },
+    "dockerImage": {
+      "type": "string",
+      "description": "Which docker image should be used for the build?",
+      "default": "openapitools/openapi-generator-cli:latest"
+    },
     "generator": {
       "type": "string",
       "description": "The OpenAPITools generator you want to use",

--- a/packages/nx-plugin-openapi/src/generators/api-lib/generator.ts
+++ b/packages/nx-plugin-openapi/src/generators/api-lib/generator.ts
@@ -1,11 +1,17 @@
 // Nrwl
 import {
-  addProjectConfiguration, formatFiles, generateFiles, GeneratorCallback,
+  addProjectConfiguration,
+  formatFiles,
+  generateFiles,
+  GeneratorCallback,
   getWorkspaceLayout,
-  joinPathFragments, names,
+  joinPathFragments,
+  names,
   offsetFromRoot,
   ProjectType,
-  readWorkspaceConfiguration, Tree, updateJson
+  readWorkspaceConfiguration,
+  Tree,
+  updateJson,
 } from '@nrwl/devkit';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 // Third Parties
@@ -15,9 +21,6 @@ import { GenerateApiLibSourcesExecutorSchema } from '../../executors/generate-ap
 import init from '../init/generator';
 // Schemas
 import { ApiLibGeneratorSchema } from './schema';
-
-
-
 
 const projectType: ProjectType = 'library';
 
@@ -82,6 +85,7 @@ function normalizeOptions(host: Tree, options: ApiLibGeneratorSchema): Normalize
 const getExecutorOptions = (options: NormalizedSchema): GenerateApiLibSourcesExecutorSchema => {
   const executorOptions: GenerateApiLibSourcesExecutorSchema = {
     useDockerBuild: options.useDockerBuild,
+    dockerImage: options.dockerImage,
     generator: options.generator,
     sourceSpecPathOrUrl: options.isRemoteSpec
       ? options.sourceSpecUrl

--- a/packages/nx-plugin-openapi/src/generators/api-lib/schema.d.ts
+++ b/packages/nx-plugin-openapi/src/generators/api-lib/schema.d.ts
@@ -1,6 +1,7 @@
 export interface ApiLibGeneratorSchema {
   name: string;
   useDockerBuild?: boolean;
+  dockerImage?: string;
   generator?: string;
   tags?: string;
   directory?: string;

--- a/packages/nx-plugin-openapi/src/generators/api-lib/schema.json
+++ b/packages/nx-plugin-openapi/src/generators/api-lib/schema.json
@@ -21,6 +21,12 @@
       "default": false,
       "x-prompt": "Should the build occur inside of a docker container?"
     },
+    "dockerImage": {
+      "type": "string",
+      "description": "Which docker image should be used for the build",
+      "default": "openapitools/openapi-generator-cli:latest",
+      "x-prompt": "Which docker image should be used for the build?"
+    },
     "generator": {
       "type": "string",
       "description": "The generator this lib will use to build an API SDK (e.g.: typescript-fetch)",


### PR DESCRIPTION
This will allow the user to pin a certain version of openapitools/openapi-generator-cli if `latest` is not appropriate or use a custom image altogether