### PR TITLE
feat(nx-plugin-openapi): add support for generator templates dir

### DIFF
--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
@@ -25,6 +25,7 @@ export default async function runExecutor(
     options.additionalProperties,
     options.globalProperties,
     options.typeMappings,
+    options.templateDir,
     outputDir,
   );
 
@@ -39,6 +40,7 @@ async function generateSources(
   additionalProperties: string,
   globalProperties: string,
   typeMappings: string,
+  templateDir: string,
   outputDir: string,
 ): Promise<number> {
   mkdirSync(outputDir, { recursive: true });
@@ -67,6 +69,10 @@ async function generateSources(
 
     if (globalProperties) {
       args.push('--global-property', globalProperties);
+    }
+
+    if (templateDir) {
+      args.push('--template-dir', templateDir);
     }
 
     const child = spawn(command, args);

--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.d.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.d.ts
@@ -6,4 +6,5 @@ export interface GenerateApiLibSourcesExecutorSchema {
   additionalProperties?: string;
   globalProperties?: string;
   typeMappings?: string;
+  templateDir?: string;
 }

--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.json
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.json
@@ -34,6 +34,10 @@
     "sourceSpecUrlAuthorizationHeaders": {
       "type": "string",
       "description": "A URL-encoded string of name:header with a comma separating multiple values"
+    },
+    "templateDir": {
+      "type": "string",
+      "description": "The path (relative to the workspace root) where the template files for the generator are located at"
     }
   },
   "required": []


### PR DESCRIPTION
Supports `--template-dir` openapi-generator config by exposing it as `templateDir` in the executor options.

Fixes #30 