### PR TITLE
Pipe through logs from the spawned openapi generator process

### DIFF
--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.spec.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.spec.ts
@@ -1,5 +1,7 @@
 jest.mock('child_process');
+jest.mock('@nrwl/devkit');
 
+import { logger } from '@nrwl/devkit';
 import { ExecutorContext } from '@nrwl/tao/src/shared/workspace';
 import { mockSpawn } from '../../test/mockSpawn';
 import executor from './executor';
@@ -13,6 +15,8 @@ describe('Command Runner Builder', () => {
   let context: (dir: string) => ExecutorContext;
   let schema: GenerateApiLibSourcesExecutorSchema;
   let dockerSchema: GenerateApiLibSourcesExecutorSchema;
+  logger.log = jest.fn();
+  logger.error = jest.fn();
 
   beforeEach(async () => {
     schema = {
@@ -79,6 +83,48 @@ describe('Command Runner Builder', () => {
       exitCode: 0,
     });
     const { success } = await executor(dockerSchema, context('docker'));
+    expect(success).toBe(true);
+    allSpawned();
+  });
+
+  it('can run with output', async () => {
+    const allSpawned = mockSpawn({
+      command: 'npx',
+      args: [
+        'openapi-generator-cli',
+        'generate',
+        ...['-i', 'open-api-spec.yml'],
+        ...['-g', 'typescript-fetch'],
+        ...['-o', './tmp/src/local'],
+      ],
+      stdout: 'stdout content',
+      stderr: 'stderr content',
+      exitCode: 0,
+    });
+    const { success } = await executor(schema, context('local'));
+    expect(success).toBe(true);
+    expect(logger.info).toHaveBeenLastCalledWith(expect.stringContaining('stdout content'));
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('stderr content'));
+    allSpawned();
+  });
+
+  it('can run without output', async () => {
+    const allSpawned = mockSpawn({
+      command: 'npx',
+      args: [
+        'openapi-generator-cli',
+        'generate',
+        ...['-i', 'open-api-spec.yml'],
+        ...['-g', 'typescript-fetch'],
+        ...['-o', './tmp/src/local'],
+      ],
+      stdout: 'stdout content',
+      stderr: 'stderr content',
+      exitCode: 0,
+    });
+    expect(logger.info).not.toHaveBeenLastCalledWith(expect.stringContaining('stdout content'));
+    expect(logger.error).not.toHaveBeenLastCalledWith(expect.stringContaining('stderr content'));
+    const { success } = await executor({ ...schema, silent: true }, context('local'));
     expect(success).toBe(true);
     allSpawned();
   });

--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/executor.ts
@@ -25,6 +25,7 @@ export default async function runExecutor(
     options.additionalProperties,
     options.globalProperties,
     options.typeMappings,
+    options.silent,
     outputDir,
   );
 
@@ -39,6 +40,7 @@ async function generateSources(
   additionalProperties: string,
   globalProperties: string,
   typeMappings: string,
+  silent: boolean,
   outputDir: string,
 ): Promise<number> {
   mkdirSync(outputDir, { recursive: true });
@@ -71,10 +73,14 @@ async function generateSources(
 
     logger.info(`[command]: ${command} ${args.join(' ')}`);
 
-    const child = spawn(command, args);
+    const child = spawn(command, args, { stdio: silent ? 'ignore' : 'pipe' });
 
     child.stdout.on('data', (data) => {
       logger.info(`[stdout]: ${data}`);
+    });
+
+    child.stderr.on('data', (data) => {
+      logger.error(`[stderr]: ${data}`);
     });
 
     child.on('error', (err) => {

--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.d.ts
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.d.ts
@@ -6,4 +6,5 @@ export interface GenerateApiLibSourcesExecutorSchema {
   additionalProperties?: string;
   globalProperties?: string;
   typeMappings?: string;
+  silent?: boolean;
 }

--- a/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.json
+++ b/packages/nx-plugin-openapi/src/executors/generate-api-lib-sources/schema.json
@@ -34,6 +34,11 @@
     "sourceSpecUrlAuthorizationHeaders": {
       "type": "string",
       "description": "A URL-encoded string of name:header with a comma separating multiple values"
+    },
+    "silent": {
+      "type": "boolean",
+      "description": "Whether or not to suppress generator output",
+      "default": false
     }
   },
   "required": []

--- a/packages/nx-plugin-openapi/src/test/mockSpawn.ts
+++ b/packages/nx-plugin-openapi/src/test/mockSpawn.ts
@@ -1,7 +1,9 @@
 import { spawn } from 'child_process';
 import EventEmitter from 'events';
 
-export function mockSpawn(...invocations: { command: string; args: string[]; stdout?: string; exitCode: number }[]) {
+export function mockSpawn(
+  ...invocations: { command: string; args: string[]; stdout?: string; stderr?: string; exitCode: number }[]
+) {
   const mock = spawn as jest.Mock;
   for (const invocation of invocations) {
     mock.mockImplementationOnce((command: string, args: string[]) => {
@@ -16,6 +18,10 @@ export function mockSpawn(...invocations: { command: string; args: string[]; std
 
       if (invocation.stdout) {
         mockEmit(child.stdout, 'data', Buffer.from(invocation.stdout));
+      }
+
+      if (invocation.stderr) {
+        mockEmit(child.stderr, 'data', Buffer.from(invocation.stderr));
       }
 
       mockEmit(child, 'exit', invocation.exitCode ?? 0);


### PR DESCRIPTION
Log the command and arguments passed to `openapi-generator-cli`

Add a handler to stdout for the spawned child process, and log data using the nx devkit logger.

Add `silent` option to suppress output

docs: add joeflateau as a contributor for doc